### PR TITLE
🧩 Extract and Prepare `vite-plugin-tanexpo`

### DIFF
--- a/.changeset/hot-beds-sing.md
+++ b/.changeset/hot-beds-sing.md
@@ -1,0 +1,5 @@
+---
+"vite-plugin-tanexpo": patch
+---
+
+Extracted vite plugin from https://github.com/nairvijays99/tanexpo-start/blob/feat-8-theme-library/apps/web/vite.config.ts

--- a/.changeset/hot-beds-sing.md
+++ b/.changeset/hot-beds-sing.md
@@ -1,5 +1,0 @@
----
-"vite-plugin-tanexpo": patch
----
-
-Extracted vite plugin from https://github.com/nairvijays99/tanexpo-start/blob/feat-8-theme-library/apps/web/vite.config.ts

--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ tanexpo-test-*/
 #yalc
 .yalc
 yalc.lock
+
+#local
+shortcuts.sh

--- a/.npmrc
+++ b/.npmrc
@@ -3,6 +3,3 @@ package-manager=pnpm@8.9.0
 
 # Prefer exact versions
 save-exact=true
-
-# npm auth for CI + local publishing
-//registry.npmjs.org/:_authToken=${NPM_TOKEN}

--- a/packages/vite-plugin/CHANGELOG.md
+++ b/packages/vite-plugin/CHANGELOG.md
@@ -1,0 +1,7 @@
+# vite-plugin-tanexpo
+
+## 0.2.0
+
+### Patch Changes
+
+- 197dba0: Extracted vite plugin from https://github.com/nairvijays99/tanexpo-start/blob/feat-8-theme-library/apps/web/vite.config.ts

--- a/packages/vite-plugin/README.md
+++ b/packages/vite-plugin/README.md
@@ -1,0 +1,48 @@
+# vite-plugin-tanexpo
+
+A Vite plugin to enable React Native Web support in TanExpo applications.
+
+## Features
+
+- **Automated Aliasing**: Automatically aliases `react-native` to `react-native-web`.
+- **Deep Redirection**: Handles internal React Native redirects for legacy library compatibility.
+- **ESM Path Correction**: Ensures compatibility for libraries like `inline-style-prefixer` and `css-in-js-utils`.
+- **Platform Extensions**: Prioritizes `.web.*` extensions for web-specific components.
+- **SSR Support**: Configures `noExternal` for seamless server-side rendering with React Native Web.
+
+## Installation
+
+```bash
+npm install vite-plugin-tanexpo --save-dev
+# or
+pnpm add -D vite-plugin-tanexpo
+# or
+yarn add -D vite-plugin-tanexpo
+```
+
+## Usage
+
+Add it to your `vite.config.ts`:
+
+```typescript
+import { defineConfig } from 'vite';
+import tanexpoVitePlugin from 'vite-plugin-tanexpo';
+
+export default defineConfig({
+  plugins: [
+    tanexpoVitePlugin({
+      externalPackages: ['some-rn-library-to-include'] // Optional
+    })
+  ]
+});
+```
+
+## Options
+
+| Option | Type | Description |
+| --- | --- | --- |
+| `externalPackages` | `string[]` | Additional packages to include in SSR `noExternal` and `optimizeDeps`. |
+
+## License
+
+MIT

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -1,8 +1,7 @@
 {
-  "name": "tanexpo-vite-plugin",
-  "private": true,
+  "name": "vite-plugin-tanexpo",
   "version": "0.1.0",
-  "description": "Vite plugin for TanExpo web apps",
+  "description": "Vite plugin for TanExpo web app",
   "author": "Vijay S Nair",
   "license": "MIT",
   "repository": {
@@ -11,10 +10,9 @@
     "url": "https://github.com/nairvijays99/tanexpo"
   },
   "keywords": [
-    "vite",
-    "expo",
-    "tanstack",
-    "plugin"
+    "vite-plugin",
+    "vite-plugin-tanexpo",
+    "tanexpo"
   ],
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",
@@ -39,7 +37,12 @@
     "prepublishOnly": "pnpm build",
     "type-check": "tsc --noEmit"
   },
-  "prepublishOnly": "pnpm build",
+  "peerDependencies": {
+    "vite": "^7.0.0"
+  },
+  "devDependencies": {
+    "vite": "^7.0.0"
+  },
   "publishConfig": {
     "access": "public"
   }

--- a/packages/vite-plugin/package.json
+++ b/packages/vite-plugin/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vite-plugin-tanexpo",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "description": "Vite plugin for TanExpo web app",
   "author": "Vijay S Nair",
   "license": "MIT",

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -10,7 +10,7 @@ interface ReactNativeWebOptions {
 export default function tanexpoVitePlugin(options: ReactNativeWebOptions = {}): Plugin {
   return {
     name: "vite-plugin-tanexpo",
-    config(config, { command, mode, isSsrBuild }) {
+    config(_config, { command, mode, isSsrBuild }) {
       const isBuild = command === "build" || isSsrBuild === true;
 
       const rnwLibraries = [

--- a/packages/vite-plugin/src/index.ts
+++ b/packages/vite-plugin/src/index.ts
@@ -1,5 +1,108 @@
-export const tanexpoVitePlugin = () => {
+import type { Plugin } from "vite";
+
+interface ReactNativeWebOptions {
+  /**
+   * Additional packages to include in SSR noExternal and optimizeDeps.
+   */
+  externalPackages?: string[];
+}
+
+export default function tanexpoVitePlugin(options: ReactNativeWebOptions = {}): Plugin {
   return {
-    name: "tanexpo-vite-plugin",
+    name: "vite-plugin-tanexpo",
+    config(config, { command, mode, isSsrBuild }) {
+      const isBuild = command === "build" || isSsrBuild === true;
+
+      const rnwLibraries = [
+        "react-native-web",
+        "inline-style-prefixer",
+        "css-to-react-native",
+        "hyphenate-style-name",
+        "style-to-css-string",
+      ];
+
+      const noExternal = [
+        ...rnwLibraries,
+        ...(options.externalPackages || []),
+        ...(isBuild ? ["styleq"] : []),
+      ];
+
+      return {
+        resolve: {
+          alias: [
+            // Standard React Native Web aliasing
+            { find: "react-native", replacement: "react-native-web" },
+            { find: /^react-native\//, replacement: "react-native-web/" },
+
+            // Deep internal redirects (often required by legacy RN libraries)
+            {
+              find: "react-native/Libraries/Image/AssetRegistry",
+              replacement: "react-native-web/dist/modules/AssetRegistry",
+            },
+            {
+              find: "react-native/Libraries/EventEmitter/RCTDeviceEventEmitter$",
+              replacement:
+                "react-native-web/dist/vendor/react-native/NativeEventEmitter/RCTDeviceEventEmitter",
+            },
+            {
+              find: "react-native/Libraries/vendor/emitter/EventEmitter$",
+              replacement: "react-native-web/dist/vendor/react-native/emitter/EventEmitter",
+            },
+            {
+              find: "react-native/Libraries/EventEmitter/NativeEventEmitter$",
+              replacement: "react-native-web/dist/vendor/react-native/NativeEventEmitter",
+            },
+
+            // Path corrections for ESM compatibility in prefixers
+            {
+              find: /^inline-style-prefixer\/lib\/(.*)/,
+              replacement: "inline-style-prefixer/es/$1",
+            },
+            {
+              find: /^inline-style-prefixer\/lib$/,
+              replacement: "inline-style-prefixer/es",
+            },
+            {
+              find: /^css-in-js-utils\/lib\/(.*)/,
+              replacement: "css-in-js-utils/es/$1",
+            },
+            {
+              find: /^css-in-js-utils\/lib$/,
+              replacement: "css-in-js-utils/es",
+            },
+
+            ...(isBuild
+              ? [
+                  { find: /^styleq\/(.*)/, replacement: "styleq/dist/$1" },
+                  { find: /^styleq$/, replacement: "styleq/dist/styleq" },
+                ]
+              : []),
+          ],
+          // Prioritize .web extensions for React Native Web support
+          extensions: [
+            ".web.tsx",
+            ".web.ts",
+            ".web.jsx",
+            ".web.js",
+            ".tsx",
+            ".ts",
+            ".jsx",
+            ".js",
+            ".mjs",
+            ".json",
+          ],
+        },
+        define: {
+          __DEV__: JSON.stringify(mode !== "production"),
+          global: "window",
+        },
+        optimizeDeps: {
+          include: rnwLibraries,
+        },
+        ssr: {
+          noExternal: noExternal,
+        },
+      };
+    },
   };
-};
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -87,7 +87,11 @@ importers:
         specifier: '*'
         version: 0.21.2(react-dom@19.2.3)(react@19.2.3)
 
-  packages/vite-plugin: {}
+  packages/vite-plugin:
+    devDependencies:
+      vite:
+        specifier: ^7.0.0
+        version: 7.3.0(@types/node@25.0.3)
 
 packages:
 


### PR DESCRIPTION
## Description

This PR extracts the Vite plugin logic from the TanExpo Start boilerplate into its own independent package within the monorepo. It also sets up the necessary documentation and configuration for its first publication to npm.

The plugin provides seamless integration for React Native Web in Vite-based projects, handling aliasing, internal redirections, and SSR support.

## Key Changes

Package Extraction: Moved plugin logic from the web app to packages/vite-plugin.
Documentation: Added a comprehensive README.md with installation guides and usage examples.
Versioning: Configured package.json for npm publication and added an initial changeset.
Quality Assurance: Fixed Biome linting issues and verified the build process via tsup.
Build Setup: Implemented dual ESM/CJS builds with automatic type generation.

## How to Test

Navigate to `packages/vite-plugin`.
Run `pnpm build` to verify the compilation.
(Optional) Run `pnpm link --global` to test the plugin locally in other projects.

## Related Issues
Closes #3 (Internal Task)

## Note for Reviewer
The package is ready for its initial release (v0.2.0). Publication will be handled post-merge from the main branch to comply with current CI/CD checks.